### PR TITLE
Feature/two lowercase letters

### DIFF
--- a/lib/mumble.rb
+++ b/lib/mumble.rb
@@ -2,6 +2,8 @@ class Mumble
   def mumble_letters(string)
     return string if string.length <= 1
 
+    return 'A-Bb' if string == 'ab'
+
     string[0] + '-' + string[1] + string[1].downcase
   end
 end

--- a/lib/mumble.rb
+++ b/lib/mumble.rb
@@ -2,8 +2,6 @@ class Mumble
   def mumble_letters(string)
     return string if string.length <= 1
 
-    return 'A-Bb' if string == 'ab'
-
-    string[0] + '-' + string[1] + string[1].downcase
+    string[0].upcase + '-' + string[1].upcase + string[1].downcase
   end
 end

--- a/spec/mumble_spec.rb
+++ b/spec/mumble_spec.rb
@@ -31,9 +31,6 @@ describe Mumble do
     context 'given a string of two lower case characters' do
       it 'returns the string mumbled' do
         expect(Mumble.new.mumble_letters('ab')).to eq 'A-Bb'
-      end
-
-      it 'returns the string mumbled' do
         expect(Mumble.new.mumble_letters('bc')).to eq 'B-Cc'
       end
     end

--- a/spec/mumble_spec.rb
+++ b/spec/mumble_spec.rb
@@ -32,6 +32,10 @@ describe Mumble do
       it 'returns the string mumbled' do
         expect(Mumble.new.mumble_letters('ab')).to eq 'A-Bb'
       end
+
+      it 'returns the string mumbled' do
+        expect(Mumble.new.mumble_letters('bc')).to eq 'B-Cc'
+      end
     end
   end
 end

--- a/spec/mumble_spec.rb
+++ b/spec/mumble_spec.rb
@@ -2,36 +2,29 @@ require('mumble')
 
 describe Mumble do
   describe '.mumble_letters' do
-    context 'given an empty string' do
-      it 'returns an empty string' do
-        expect(Mumble.new.mumble_letters('')).to eq ''
-      end
-    end
+    expectations = [
+      { input: '', expected_output: '' },
+      { input: 'A', expected_output: 'A' },
+      { input: 'B', expected_output: 'B' },
+      { input: 'AB', expected_output: 'A-Bb' },
+      { input: 'BC', expected_output: 'B-Cc' },
+      { input: 'CD', expected_output: 'C-Dd' },
+      { input: 'ab', expected_output: 'A-Bb' },
+      { input: 'bc', expected_output: 'B-Cc' }
+    ]
 
-    context 'given a single upper case character string' do
-      it 'returns the given string' do
-        expect(Mumble.new.mumble_letters('A')).to eq 'A'
-      end
-    end
+    expectations.each do |test_case|
+      context "given #{test_case[:input]}" do
+        it "expect #{test_case[:expected_output]}" do
+          # Arrange
+          mumbler = Mumble.new
 
-    context 'given another uppercase character string' do
-      it 'returns the given string' do
-        expect(Mumble.new.mumble_letters('B')).to eq 'B'
-      end
-    end
+          # Act
+          output = mumbler.mumble_letters(test_case[:input])
 
-    context 'given a string of two upper case characters' do
-      it 'returns the string mumbled' do
-        expect(Mumble.new.mumble_letters('AB')).to eq 'A-Bb'
-        expect(Mumble.new.mumble_letters('BC')).to eq 'B-Cc'
-        expect(Mumble.new.mumble_letters('CD')).to eq 'C-Dd'
-      end
-    end
-
-    context 'given a string of two lower case characters' do
-      it 'returns the string mumbled' do
-        expect(Mumble.new.mumble_letters('ab')).to eq 'A-Bb'
-        expect(Mumble.new.mumble_letters('bc')).to eq 'B-Cc'
+          # Assert
+          expect(output).to eq test_case[:expected_output]
+        end
       end
     end
   end

--- a/spec/mumble_spec.rb
+++ b/spec/mumble_spec.rb
@@ -27,5 +27,11 @@ describe Mumble do
         expect(Mumble.new.mumble_letters('CD')).to eq 'C-Dd'
       end
     end
+
+    context 'given a string of two lower case characters' do
+      it 'returns the string mumbled' do
+        expect(Mumble.new.mumble_letters('ab')).to eq 'A-Bb'
+      end
+    end
   end
 end


### PR DESCRIPTION
Propose to complete feature two_lowercase_letters and merge. 🥳

The following tests now pass:

```ruby
      { input: 'ab', expected_output: 'A-Bb' },
      { input: 'bc', expected_output: 'B-Cc' },
      { input: 'cd', expected_output: 'C-Dd' },
```

I've also refactored the tests in to an array of expectations:

```ruby
describe Mumble do
  describe '.mumble_letters' do
    expectations = [
      { input: '', expected_output: '' },
      { input: 'A', expected_output: 'A' },
      { input: 'B', expected_output: 'B' },
      { input: 'AB', expected_output: 'A-Bb' },
      { input: 'BC', expected_output: 'B-Cc' },
      { input: 'CD', expected_output: 'C-Dd' },
      { input: 'ab', expected_output: 'A-Bb' },
      { input: 'bc', expected_output: 'B-Cc' },
      { input: 'cd', expected_output: 'C-Dd' },
      { input: 'ABC', expected_output: 'A-Bb-Ccc' }
    ]

    expectations.each do |test_case|
      context "given #{test_case[:input]}," do
        it "expect #{test_case[:expected_output]}" do
          # Arrange
          mumbler = Mumble.new

          # Act
          output = mumbler.mumble_letters(test_case[:input])

          # Assert
          expect(output).to eq test_case[:expected_output]
        end
      end
    end
  end
end
```